### PR TITLE
corriger les liens manquants dans le menu de navigation bénévole

### DIFF
--- a/GroLoto/templates/sidebar/_nav_benevole.html.twig
+++ b/GroLoto/templates/sidebar/_nav_benevole.html.twig
@@ -15,8 +15,8 @@
             <span class="nav-text">Festivals</span>
         </a>
         <ul class="submenu">
-            <li><a href="">Voir les Weekends</a></li>
-            <li><a href="">Voir les Évenements</a></li>
+            <li><a href="{{ path('app_weekends') }}">Voir les Weekends</a></li>
+            <li><a href="{{ path('app_evenements') }}">Voir les Évenements</a></li>
             <li><a href="{{ path('benevole_taches_disponibles') }}">S'inscrire à une tâche</a></li>
         </ul>
     </li>


### PR DESCRIPTION
- Ajouter le lien vers 'Voir les Weekends' (app_weekends)
- Ajouter le lien vers 'Voir les Événements' (app_evenements)
- Les pages sont maintenant accessibles via le menu